### PR TITLE
fix: apply safe area insets to bottom tab bar on Android

### DIFF
--- a/app/authorized/_layout.tsx
+++ b/app/authorized/_layout.tsx
@@ -125,6 +125,8 @@ export default function RootLayout() {
 					tabBarStyle: {
 						backgroundColor: Colors.backgrounds.primaryBackground,
 						borderTopColor: Colors.greys.whiteAlpha60,
+						paddingBottom: insets.bottom,
+						height: 49 + insets.bottom,
 					},
 					sceneStyle: { backgroundColor: "transparent" },
 				}}


### PR DESCRIPTION
The tabBarStyle was missing paddingBottom and height adjustments for Android system navigation controls, causing the tab bar to be partially obscured. Apply insets.bottom (already provided by useSafeAreaInsets) to ensure the bar sits above the system gesture/button area.

Fixes #25