### PR TITLE
fix: stop audio looping on Android by pausing on didJustFinish

### DIFF
--- a/components/PlayWordButton/PlayWordButton.tsx
+++ b/components/PlayWordButton/PlayWordButton.tsx
@@ -44,17 +44,16 @@ export const PlayWordButton = ({ autoplay, audio }: PlayWordButtonProps) => {
 			return;
 		}
 
+		player.loop = false;
+
 		const listener = (status: AudioStatus) => {
 			setIsPlaying(status.playing);
-			if (
-				status.duration &&
-				status.duration > 0 &&
-				status.currentTime >= status.duration
-			) {
+			if (status.didJustFinish) {
 				try {
+					player.pause();
 					player.seekTo(0);
 				} catch (error) {
-					logger.error("Error seeking audio:", error, "audio");
+					logger.error("Error stopping audio:", error, "audio");
 				}
 			}
 		};


### PR DESCRIPTION
The playbackStatusUpdate listener was calling seekTo(0) when currentTime >= duration, but never pausing the player. On Android the player remained in a playing state after seeking, causing it to restart from the beginning indefinitely.

Fix:
- Set player.loop = false explicitly to disable native looping
- Replace the manual time-comparison check with status.didJustFinish
- Call player.pause() before seekTo(0) so playback actually stops

Fixes #26