### PR TITLE
fix: always include correct answer in choose translation options

### DIFF
--- a/components/TrainingExercises/ChooseTranslationExercise.tsx
+++ b/components/TrainingExercises/ChooseTranslationExercise.tsx
@@ -51,12 +51,11 @@ export function ChooseTranslationExercise() {
 			return [];
 		}
 
-		const options = [
-			translation.translation,
-			...randomTranslations.map((t) => t.translation),
-		];
+		const distractors = randomTranslations
+			.map((t) => t.translation)
+			.slice(0, 3);
 
-		return shuffleArray(Array.from(options)).slice(0, 4);
+		return shuffleArray([translation.translation, ...distractors]);
 	}, [randomTranslations, translation]);
 
 	const [selectedOption, setSelectedOption] = useState<string | null>(null);


### PR DESCRIPTION
Previously, shuffleArray was called on all options before slicing to 4, which could exclude the correct answer if it landed beyond index 3.

Now we take 3 distractors first, then shuffle with the correct answer already included, guaranteeing it always appears in the options.

Fixes #28