### PR TITLE
feat: show topic name translation in user's native language

### DIFF
--- a/app/authorized/catalog.tsx
+++ b/app/authorized/catalog.tsx
@@ -31,6 +31,7 @@ export default function Catalog() {
 
 	const [catalogs, setCatalogs] = useState<VocabCatalog[]>([]);
 	const [topics, setTopics] = useState<Topic[]>([]);
+	const [topicTranslations, setTopicTranslations] = useState<Map<number, string>>(new Map());
 
 	const filterTopics = useCallback(async (): Promise<Topic[]> => {
 		if (currentCatalogs.length === 0) {
@@ -132,6 +133,20 @@ export default function Catalog() {
 		})();
 	}, [user?.language_learn, fetchCatalogs, fetchTopics]);
 
+	useEffect(() => {
+		if (!user?.language_speak || user.language_speak === user?.language_learn) {
+			setTopicTranslations(new Map());
+			return;
+		}
+		topicsRepository.getByLanguage(user.language_speak).then((translated) => {
+			const map = new Map<number, string>();
+			for (const t of translated) {
+				map.set(t.remoteId, t.title);
+			}
+			setTopicTranslations(map);
+		});
+	}, [user?.language_speak, user?.language_learn]);
+
 	// Auto-select A1 + A2 by default only on first launch (nothing persisted)
 	useEffect(() => {
 		if (_hasHydrated && catalogs.length > 0 && currentCatalogs.length === 0) {
@@ -170,6 +185,7 @@ export default function Catalog() {
 		return (
 			<TopicItem
 				title={item.item.title}
+				translatedTitle={topicTranslations.get(item.item.remoteId)}
 				selected={currentTopics.includes(item.item.remoteId)}
 				onPress={() => toggleTopic(item.item.remoteId)}
 				learnedCount={stats?.learned}

--- a/components/TopicItem/TopicItem.tsx
+++ b/components/TopicItem/TopicItem.tsx
@@ -8,6 +8,7 @@ type TopicItemProps = Pick<Topic, "title"> & {
 	onPress: () => void;
 	learnedCount?: number;
 	totalCount?: number;
+	translatedTitle?: string;
 };
 
 export const TopicItem = (props: TopicItemProps) => {
@@ -27,9 +28,16 @@ export const TopicItem = (props: TopicItemProps) => {
 						justifyContent: "space-between",
 					}}
 				>
-					<WText mode="primary" size="xl" align="left" style={{ flex: 1 }}>
-						{props.title}
-					</WText>
+					<View style={{ flex: 1 }}>
+						<WText mode="primary" size="xl" align="left">
+							{props.title}
+						</WText>
+						{props.translatedTitle && (
+							<WText mode="secondary" size="sm" align="left">
+								{props.translatedTitle}
+							</WText>
+						)}
+					</View>
 					{props.totalCount !== undefined && (
 						<WText
 							mode="secondary"


### PR DESCRIPTION
Fetch topics in the user's speaking language and display the translated title as a subtitle below the original topic name in the catalog list. Falls back gracefully when no translation is available or when the speaking and learning languages are the same.

Fixes #34