### PR TITLE
fix: re-sync vocabulary when learning language changes in settings

### DIFF
--- a/app/authorized/_layout.tsx
+++ b/app/authorized/_layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout() {
 	const { isSyncing } = useVocabularyStore();
 	const { setCurrentCatalogs, setCurrentTopics, setHasHydrated, _hasHydrated } =
 		useExcerciseStore();
-	const hasSyncedRef = useRef(false);
+	const lastSyncedLanguageRef = useRef<string | null>(null);
 
 	useEffect(() => {
 		if (!user?.userId || _hasHydrated) return;
@@ -68,7 +68,7 @@ export default function RootLayout() {
 
 	useEffect(() => {
 		if (!user) {
-			hasSyncedRef.current = false;
+			lastSyncedLanguageRef.current = null;
 			return;
 		}
 
@@ -79,12 +79,12 @@ export default function RootLayout() {
 		const timeoutId = setTimeout(() => controller.abort(), 2500);
 
 		const checkOnlineAndSync = async () => {
-			if (isSyncing || hasSyncedRef.current) {
+			if (isSyncing || lastSyncedLanguageRef.current === user.language_learn) {
 				return;
 			}
 
 			if (!server) {
-				hasSyncedRef.current = true;
+				lastSyncedLanguageRef.current = user.language_learn;
 				syncVocabulary(user.language_learn as Language);
 				return;
 			}
@@ -95,7 +95,7 @@ export default function RootLayout() {
 					signal: controller.signal,
 				});
 				if (res) {
-					hasSyncedRef.current = true;
+					lastSyncedLanguageRef.current = user.language_learn;
 					syncVocabulary(user.language_learn as Language);
 				}
 			} catch {


### PR DESCRIPTION
Replace the one-shot `hasSyncedRef` boolean with `lastSyncedLanguageRef` that tracks the last synced `language_learn` value. When the user changes their learning language in the profile screen, the layout's sync effect now detects the mismatch and triggers a full vocabulary re-sync for the new language.

Fixes #33