### PR TITLE
fix: re-trigger biometric auth when app resumes from background

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -87,14 +87,19 @@ export default Sentry.wrap(function RootLayout() {
 				backgroundedAt.current = null;
 
 				if (elapsed >= BACKGROUND_TIMEOUT_MS && isAuthenticated) {
-					setIsReady(false);
-					triggerBiometricAuth();
+					const result = await authenticateAsync({
+						promptMessage: "Authenticate to access the app",
+					});
+
+					if (!result.success) {
+						setAuthenticated(false);
+					}
 				}
 			}
 		});
 
 		return () => subscription.remove();
-	}, [isAuthenticated, triggerBiometricAuth]);
+	}, [isAuthenticated]);
 
 	useEffect(() => {
 		if (isAuthenticated) {


### PR DESCRIPTION
If the app was backgrounded for more than 60 seconds, require biometric re-authentication when the user returns to the app. Uses AppState to detect background→active transitions and a timestamp-based timeout to avoid interrupting brief switches.

Fixes #22