### PR TITLE
feat: add segmented progress bar to topic list items

### DIFF
--- a/app/authorized/catalog.tsx
+++ b/app/authorized/catalog.tsx
@@ -43,7 +43,7 @@ export default function Catalog() {
 
 	const [filteredTopics, setFilteredTopics] = useState<Topic[]>([]);
 	const [topicStats, setTopicStats] = useState<
-		Map<number, { total: number; learned: number }>
+		Map<number, { total: number; green: number; yellow: number }>
 	>(new Map());
 
 	useEffect(() => {
@@ -64,13 +64,28 @@ export default function Catalog() {
 				progressRecords.map((p) => [p.wordId, p]),
 			);
 
-			const stats = new Map<number, { total: number; learned: number }>();
+			const threeMonthsAgo = new Date();
+			threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+
+			const stats = new Map<
+				number,
+				{ total: number; green: number; yellow: number }
+			>();
 			for (const word of words) {
-				const entry = stats.get(word.topic) ?? { total: 0, learned: 0 };
+				const entry = stats.get(word.topic) ?? {
+					total: 0,
+					green: 0,
+					yellow: 0,
+				};
 				entry.total += 1;
 				const progress = progressByWordId.get(word.remoteId);
 				if (progress && progress.score >= 1) {
-					entry.learned += 1;
+					const lastReview = new Date(progress.lastReview);
+					if (lastReview >= threeMonthsAgo) {
+						entry.green += 1;
+					} else {
+						entry.yellow += 1;
+					}
 				}
 				stats.set(word.topic, entry);
 			}
@@ -172,8 +187,9 @@ export default function Catalog() {
 				title={item.item.title}
 				selected={currentTopics.includes(item.item.remoteId)}
 				onPress={() => toggleTopic(item.item.remoteId)}
-				learnedCount={stats?.learned}
 				totalCount={stats?.total}
+				greenCount={stats?.green}
+				yellowCount={stats?.yellow}
 			/>
 		);
 	};

--- a/components/TopicItem/TopicItem.tsx
+++ b/components/TopicItem/TopicItem.tsx
@@ -6,11 +6,23 @@ import { Colors } from "@/mob-ui/brand/colors";
 type TopicItemProps = Pick<Topic, "title"> & {
 	selected: boolean;
 	onPress: () => void;
-	learnedCount?: number;
 	totalCount?: number;
+	greenCount?: number;
+	yellowCount?: number;
 };
 
+const PROGRESS_BAR_HEIGHT = 4;
+const PROGRESS_BAR_RADIUS = 2;
+
 export const TopicItem = (props: TopicItemProps) => {
+	const { totalCount, greenCount = 0, yellowCount = 0 } = props;
+	const greyCount =
+		totalCount !== undefined
+			? Math.max(0, totalCount - greenCount - yellowCount)
+			: undefined;
+
+	const showBar = totalCount !== undefined && totalCount > 0;
+
 	return (
 		<Pressable onPress={props.onPress}>
 			<WCard
@@ -30,17 +42,53 @@ export const TopicItem = (props: TopicItemProps) => {
 					<WText mode="primary" size="xl" align="left" style={{ flex: 1 }}>
 						{props.title}
 					</WText>
-					{props.totalCount !== undefined && (
+					{totalCount !== undefined && (
 						<WText
 							mode="secondary"
 							size="md"
 							align="right"
 							style={{ flexShrink: 0, marginLeft: 8 }}
 						>
-							{props.learnedCount ?? 0}/{props.totalCount}
+							{greenCount + yellowCount}/{totalCount}
 						</WText>
 					)}
 				</View>
+				{showBar && (
+					<View
+						style={{
+							flexDirection: "row",
+							height: PROGRESS_BAR_HEIGHT,
+							borderRadius: PROGRESS_BAR_RADIUS,
+							overflow: "hidden",
+							marginTop: 8,
+						}}
+					>
+						{greenCount > 0 && (
+							<View
+								style={{
+									flex: greenCount,
+									backgroundColor: Colors.accents.green,
+								}}
+							/>
+						)}
+						{yellowCount > 0 && (
+							<View
+								style={{
+									flex: yellowCount,
+									backgroundColor: Colors.backgrounds.yellow,
+								}}
+							/>
+						)}
+						{(greyCount ?? 0) > 0 && (
+							<View
+								style={{
+									flex: greyCount,
+									backgroundColor: Colors.greys.grey4,
+								}}
+							/>
+						)}
+					</View>
+				)}
 			</WCard>
 		</Pressable>
 	);


### PR DESCRIPTION
Each topic card now shows a colour-coded horizontal bar split into green (passed < 3 months ago), yellow (needs revision ≥ 3 months), and grey (not yet attempted) segments proportional to word counts. The word-count badge is updated to reflect passed+revision / total.

Closes #30