### PR TITLE
fix: show word count per topic for selected level only

### DIFF
--- a/app/authorized/catalog.tsx
+++ b/app/authorized/catalog.tsx
@@ -64,7 +64,7 @@ export default function Catalog() {
 
 		(async () => {
 			const topicIds = filteredTopics.map((t) => t.remoteId);
-			const words = await wordsRepository.getByTopicIds(topicIds);
+			const words = await wordsRepository.getByTopicIds(topicIds, currentCatalogs);
 
 			const progressRecords = await learningRepository.getByUser(user.userId);
 			const progressByWordId = new Map(
@@ -100,7 +100,7 @@ export default function Catalog() {
 			}
 			setTopicStats(stats);
 		})();
-	}, [filteredTopics, user?.userId]);
+	}, [filteredTopics, user?.userId, currentCatalogs]);
 
 	// Only auto-select topics when the user explicitly toggles a catalog, not on mount or hydration
 	const catalogJustToggledRef = useRef(false);

--- a/db/repositories/words.repository.ts
+++ b/db/repositories/words.repository.ts
@@ -185,11 +185,15 @@ export const wordsRepository = {
 		return new Set(words.map((word) => word.topic));
 	},
 
-	async getByTopicIds(topicIds: number[]): Promise<Word[]> {
+	async getByTopicIds(topicIds: number[], catalogIds?: number[]): Promise<Word[]> {
 		if (topicIds.length === 0) return [];
+		const conditions = [Q.where("topic", Q.oneOf(topicIds))];
+		if (catalogIds && catalogIds.length > 0) {
+			conditions.push(Q.where("catalog", Q.oneOf(catalogIds)));
+		}
 		return database
 			.get<Word>("words")
-			.query(Q.where("topic", Q.oneOf(topicIds)))
+			.query(...conditions)
 			.fetch();
 	},
 };


### PR DESCRIPTION
Filter words by selected catalogs when computing topic stats, so total/learned counts reflect only words for the active level(s). Topics with no words for the selected level are already hidden via filterTopics(). Closes #59