### PR TITLE
fix: only trigger biometric auth on app launch when token exists

### DIFF
--- a/app/verify.tsx
+++ b/app/verify.tsx
@@ -1,5 +1,4 @@
 import { AntDesign } from "@expo/vector-icons";
-import { authenticateAsync } from "expo-local-authentication";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,15 +24,7 @@ export default function Verify() {
 			try {
 				await verifyEmail({ code: text, email });
 
-				const result = await authenticateAsync({
-					promptMessage: "Authenticate to access the app",
-				});
-
-				if (!result.success) {
-					router.push("/");
-				} else {
-					router.push("/authorized/learning");
-				}
+				router.push("/authorized/learning");
 			} catch (e) {
 				setError((e as Error).message);
 			}

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,7 +1,6 @@
 import { Q } from "@nozbe/watermelondb";
 import { useDatabase } from "@nozbe/watermelondb/hooks";
 import { components } from "@vvruspat/words-types";
-import { authenticateAsync, hasHardwareAsync, isEnrolledAsync } from "expo-local-authentication";
 import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { jwtDecode } from "jwt-decode";
@@ -79,20 +78,6 @@ export const useSessionUser = () => {
 		// This will trigger the useEffect to observe the user
 		setAccessToken(accessToken);
 		setRefreshToken(refreshToken);
-
-		const hasHardware = await hasHardwareAsync();
-		const isEnrolled = await isEnrolledAsync();
-
-		if (hasHardware && isEnrolled) {
-			const result = await authenticateAsync({
-				promptMessage: "Authenticate to access the app",
-			});
-
-			if (!result.success) {
-				router.push("/");
-				return;
-			}
-		}
 
 		router.push("/authorized/learning");
 	};


### PR DESCRIPTION
Removed biometric prompts from authUser() and verify.tsx so they no longer fire during the sign-up/sign-in flow. Biometric auth now runs exclusively in _layout.tsx, which already guards it behind an existing access_token check — ensuring biometric is only used to unlock a pre-established session, not during initial registration.