### PR TITLE
Fix duplicate topic prompt and exercise reset on topic switch

### DIFF
--- a/components/TrainingAppWrapper/TrainingAppWrapper.tsx
+++ b/components/TrainingAppWrapper/TrainingAppWrapper.tsx
@@ -385,7 +385,8 @@ export const TrainingAppWrapper = ({
 			!previousTopicCompleteRef.current &&
 			isCurrentTopicComplete &&
 			successEventCount > 0 &&
-			nextTopicId != null
+			nextTopicId != null &&
+			!showNextTopicPrompt
 		) {
 			setShowMasteredPrompt(false);
 
@@ -404,7 +405,7 @@ export const TrainingAppWrapper = ({
 		}
 
 		previousTopicCompleteRef.current = isCurrentTopicComplete;
-	}, [isCurrentTopicComplete, nextTopicId, selectedTopicId, successEventCount]);
+	}, [isCurrentTopicComplete, nextTopicId, selectedTopicId, showNextTopicPrompt, successEventCount]);
 
 	useEffect(() => {
 		if (
@@ -468,7 +469,8 @@ export const TrainingAppWrapper = ({
 
 		setShowNextTopicPrompt(false);
 		setCurrentTopics([nextTopicId]);
-	}, [nextTopicId, setCurrentTopics]);
+		setCurrentExercise(orderedTrainingIds[0] ?? null);
+	}, [nextTopicId, orderedTrainingIds, setCurrentTopics]);
 
 	return (
 		<KeyboardAvoidingView


### PR DESCRIPTION
- Prevent Effect 2 from re-showing the next-topic prompt when Effect 1 already displayed it by guarding on !showNextTopicPrompt
- Reset exercise to the first (cards) when navigating to a new topic