### PR TITLE
feat: chunk-based word learning with intro flow and failure bug fix

### DIFF
--- a/app/authorized/learning/index.tsx
+++ b/app/authorized/learning/index.tsx
@@ -1,9 +1,14 @@
 import { LearningCatalog } from "@/components/LearningCatalog";
+import { learningRepository } from "@/db/repositories/learning.repository";
+import { wordsRepository } from "@/db/repositories/words.repository";
 import { BackgroundContext } from "@/context/BackgroundContext";
-import { WButton, WText } from "@/mob-ui";
+import { useChunkManagement, CHUNK_SIZE } from "@/hooks/useChunkManagement";
+import { useExcerciseStore } from "@/hooks/useExcerciseStore";
+import { useSessionUser } from "@/hooks/useSession";
+import { WButton, WCard, WText } from "@/mob-ui";
 import { Colors } from "@/mob-ui/brand/colors";
 import { router } from "expo-router";
-import { useContext, useEffect } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -12,15 +17,120 @@ import { styles } from "../../../general.styles";
 export default function Learning() {
 	const { setColor, setOpacity } = useContext(BackgroundContext);
 	const { t } = useTranslation();
+	const { user } = useSessionUser();
+	const { currentCatalogs, currentTopics, setChunkWordIds } =
+		useExcerciseStore();
+
+	const userId = user?.userId != null ? String(user.userId) : undefined;
+	const { shouldShowProposal, loading: chunkLoading, markProposed } =
+		useChunkManagement(userId, currentTopics, currentCatalogs);
+
+	const [untrainedWords, setUntrainedWords] = useState<{ remoteId: number }[]>(
+		[],
+	);
+	const [proposalDismissed, setProposalDismissed] = useState(false);
+
+	// Load untrained words when conditions might warrant showing proposal
+	useEffect(() => {
+		if (!user?.userId || !user?.language_learn) return;
+		wordsRepository
+			.getOrderedUntrainedWords(
+				user.language_learn,
+				CHUNK_SIZE,
+				user.userId,
+				currentTopics.length > 0 ? currentTopics : undefined,
+				currentCatalogs.length > 0 ? currentCatalogs : undefined,
+			)
+			.then(setUntrainedWords);
+	}, [user?.userId, user?.language_learn, currentTopics, currentCatalogs]);
 
 	useEffect(() => {
 		setColor(Colors.backgrounds.green);
 		setOpacity(1);
-
 		return () => {
 			setOpacity(0.3);
 		};
 	}, [setColor, setOpacity]);
+
+	const showProposal =
+		!chunkLoading &&
+		shouldShowProposal &&
+		untrainedWords.length > 0 &&
+		!proposalDismissed;
+
+	const handleLearn = useCallback(async () => {
+		await markProposed();
+		const wordIds = untrainedWords.map((w) => w.remoteId).join(",");
+		router.push({
+			pathname: "/authorized/learning/word-intro",
+			params: { wordIds },
+		});
+	}, [markProposed, untrainedWords]);
+
+	const handleTrainChunk = useCallback(async () => {
+		await markProposed();
+		if (!user?.userId) return;
+		const allRecords = await learningRepository.getByUser(user.userId);
+		const introducedIds = allRecords
+			.filter((r) => r.training === "intro")
+			.map((r) => r.wordId);
+		setChunkWordIds(introducedIds.length > 0 ? introducedIds : null);
+		router.push({ pathname: "/authorized/learning/mix-training" });
+	}, [markProposed, user?.userId, setChunkWordIds]);
+
+	const handleTrainAll = useCallback(async () => {
+		await markProposed();
+		setChunkWordIds(null);
+		setProposalDismissed(true);
+	}, [markProposed, setChunkWordIds]);
+
+	if (showProposal) {
+		return (
+			<SafeAreaView mode="padding" edges={["top"]} style={styles.page}>
+				<View
+					style={{
+						gap: 16,
+						flex: 1,
+						width: "100%",
+						alignItems: "flex-start",
+						justifyContent: "flex-start",
+					}}
+				>
+					<WText mode="primary" size="2xl">
+						{t("learning_title")}
+					</WText>
+
+					<WCard
+						style={{
+							width: "100%",
+							gap: 16,
+							padding: 20,
+							backgroundColor: Colors.dark.dark2,
+						}}
+					>
+						<WText mode="primary" size="lg" weight="semibold" wrap>
+							{t("daily_proposal_title", { count: untrainedWords.length })}
+						</WText>
+						<WText mode="secondary" size="sm" wrap>
+							{t("daily_proposal_description")}
+						</WText>
+					</WCard>
+
+					<WButton mode="primary" fullWidth onPress={handleLearn}>
+						<WText mode="inverted">{t("daily_proposal_learn")}</WText>
+					</WButton>
+
+					<WButton mode="dark" fullWidth onPress={handleTrainChunk}>
+						<WText>{t("daily_proposal_train_chunk")}</WText>
+					</WButton>
+
+					<WButton mode="dark" fullWidth onPress={handleTrainAll}>
+						<WText>{t("daily_proposal_train_all")}</WText>
+					</WButton>
+				</View>
+			</SafeAreaView>
+		);
+	}
 
 	return (
 		<SafeAreaView mode="padding" edges={["top"]} style={styles.page}>

--- a/app/authorized/learning/word-intro.tsx
+++ b/app/authorized/learning/word-intro.tsx
@@ -1,0 +1,243 @@
+import { router, useLocalSearchParams } from "expo-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+	KeyboardAvoidingView,
+	Platform,
+	StyleSheet,
+	TextInput,
+	View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { PlayWordButton } from "@/components/PlayWordButton";
+import { learningRepository } from "@/db/repositories/learning.repository";
+import { translationsRepository } from "@/db/repositories/translations.repository";
+import { wordsRepository } from "@/db/repositories/words.repository";
+import WatermelonWord from "@/db/models/Word";
+import WatermelonWordTranslation from "@/db/models/WordTranslation";
+import { useExcerciseStore } from "@/hooks/useExcerciseStore";
+import { useSessionUser } from "@/hooks/useSession";
+import { WButton, WCard, WText } from "@/mob-ui";
+import { Colors } from "@/mob-ui/brand/colors";
+
+type WordPair = {
+	word: WatermelonWord;
+	translation: WatermelonWordTranslation;
+};
+
+export default function WordIntro() {
+	const { t } = useTranslation();
+	const { wordIds } = useLocalSearchParams<{ wordIds: string }>();
+	const { user } = useSessionUser();
+	const { setChunkWordIds } = useExcerciseStore();
+
+	const [pairs, setPairs] = useState<WordPair[]>([]);
+	const [currentIndex, setCurrentIndex] = useState(0);
+	const [typed, setTyped] = useState("");
+	const [loading, setLoading] = useState(true);
+
+	const ids = wordIds
+		? wordIds
+				.split(",")
+				.map(Number)
+				.filter((n) => !Number.isNaN(n))
+		: [];
+
+	useEffect(() => {
+		if (!ids.length || !user?.language_speak) return;
+		wordsRepository
+			.getByRemoteIds(ids, user.language_learn ?? "en")
+			.then(async (fetchedWords) => {
+				const ordered = ids
+					.map((id) => fetchedWords.find((w) => w.remoteId === id))
+					.filter(Boolean) as WatermelonWord[];
+				const translations = await translationsRepository.getByWordIds(
+					user.language_speak ?? "en",
+					ordered.map((w) => w.remoteId),
+				);
+				const loadedPairs = ordered
+					.map((word) => ({
+						word,
+						translation: translations.find((t) => t.word === word.remoteId),
+					}))
+					.filter((p): p is WordPair => p.translation !== undefined);
+				setPairs(loadedPairs);
+			})
+			.finally(() => setLoading(false));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [wordIds, user?.language_speak, user?.language_learn]);
+
+	const handleNext = useCallback(async () => {
+		const pair = pairs[currentIndex];
+		if (!pair || !user?.userId) return;
+
+		await learningRepository.recordIntro({
+			userId: user.userId,
+			wordId: pair.word.remoteId,
+			translationId: pair.translation.remoteId,
+		});
+
+		const isLast = currentIndex === pairs.length - 1;
+
+		if (!isLast) {
+			setCurrentIndex((i) => i + 1);
+			setTyped("");
+			return;
+		}
+
+		// All words introduced — collect ALL introduced word IDs for this user.
+		// ExerciseContext will intersect these with the current topic/catalog scope.
+		const allRecords = await learningRepository.getByUser(user.userId);
+		const allIntroducedIds = allRecords
+			.filter((r) => r.training === "intro")
+			.map((r) => r.wordId);
+
+		setChunkWordIds(allIntroducedIds.length > 0 ? allIntroducedIds : ids);
+		router.replace("/authorized/learning/mix-training");
+	}, [pairs, currentIndex, user, ids, setChunkWordIds]);
+
+	if (loading) {
+		return (
+			<SafeAreaView style={styles.page}>
+				<WText mode="secondary">{t("button_continue")}…</WText>
+			</SafeAreaView>
+		);
+	}
+
+	const pair = pairs[currentIndex];
+	if (!pair) return null;
+
+	const isLast = currentIndex === pairs.length - 1;
+
+	return (
+		<SafeAreaView mode="padding" edges={["top", "bottom"]} style={styles.page}>
+			<KeyboardAvoidingView
+				behavior={Platform.OS === "ios" ? "padding" : "height"}
+				style={styles.keyboardView}
+			>
+				<View style={styles.header}>
+					<WText mode="secondary" size="md">
+						{currentIndex + 1} / {pairs.length}
+					</WText>
+				</View>
+
+				<WCard style={styles.card}>
+					<View style={styles.cardContent}>
+						<WText mode="primary" weight="bold" size="2xl" wrap style={styles.word}>
+							{pair.word.word}
+						</WText>
+
+						{pair.word.transcription ? (
+							<WText mode="secondary" size="xl" style={styles.transcription}>
+								{pair.word.transcription}
+							</WText>
+						) : null}
+
+						<View style={styles.divider} />
+
+						<WText
+							mode="primary"
+							size="xl"
+							wrap
+							style={styles.translation}
+						>
+							{pair.translation.translation}
+						</WText>
+
+						<PlayWordButton audio={pair.word.audio} autoplay />
+					</View>
+				</WCard>
+
+				<View style={styles.practiceSection}>
+					<WText mode="secondary" size="sm" style={styles.practiceHint}>
+						{t("word_intro_type_hint")}
+					</WText>
+					<TextInput
+						style={[
+							styles.input,
+							typed.toLowerCase().trim() ===
+								pair.word.word.toLowerCase().trim() && styles.inputCorrect,
+						]}
+						value={typed}
+						onChangeText={setTyped}
+						placeholder={pair.word.word}
+						placeholderTextColor={Colors.greys.grey5}
+						autoCapitalize="none"
+						autoCorrect={false}
+						returnKeyType="done"
+					/>
+				</View>
+
+				<WButton mode="primary" fullWidth onPress={handleNext}>
+					<WText mode="inverted">
+						{isLast ? t("word_intro_done") : t("word_intro_next")}
+					</WText>
+				</WButton>
+			</KeyboardAvoidingView>
+		</SafeAreaView>
+	);
+}
+
+const styles = StyleSheet.create({
+	page: {
+		flex: 1,
+		backgroundColor: Colors.backgrounds.primaryBackground,
+		paddingHorizontal: 16,
+	},
+	keyboardView: {
+		flex: 1,
+		gap: 16,
+	},
+	header: {
+		alignItems: "center",
+		paddingTop: 8,
+	},
+	card: {
+		flex: 1,
+		padding: 0,
+		backgroundColor: Colors.backgrounds.primaryBackground,
+		borderWidth: 1,
+		borderColor: Colors.greys.grey3,
+	},
+	cardContent: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		gap: 16,
+		padding: 24,
+	},
+	word: {
+		textAlign: "center",
+	},
+	transcription: {
+		textAlign: "center",
+	},
+	divider: {
+		width: 48,
+		height: 2,
+		borderRadius: 1,
+		backgroundColor: Colors.greys.grey4,
+	},
+	translation: {
+		textAlign: "center",
+	},
+	practiceSection: {
+		gap: 8,
+	},
+	practiceHint: {
+		textAlign: "center",
+	},
+	input: {
+		borderWidth: 1,
+		borderColor: Colors.greys.grey4,
+		borderRadius: 12,
+		padding: 14,
+		fontSize: 16,
+		color: Colors.greys.white,
+		backgroundColor: Colors.greys.grey10,
+		textAlign: "center",
+	},
+	inputCorrect: {
+		borderColor: Colors.accents.green,
+	},
+});

--- a/app/authorized/learning/word-intro.tsx
+++ b/app/authorized/learning/word-intro.tsx
@@ -1,5 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	KeyboardAvoidingView,
@@ -25,6 +25,14 @@ type WordPair = {
 	translation: WatermelonWordTranslation;
 };
 
+function parseWordIds(raw: string | undefined): number[] {
+	if (!raw) return [];
+	return raw
+		.split(",")
+		.map(Number)
+		.filter((n) => !Number.isNaN(n));
+}
+
 export default function WordIntro() {
 	const { t } = useTranslation();
 	const { wordIds } = useLocalSearchParams<{ wordIds: string }>();
@@ -36,15 +44,11 @@ export default function WordIntro() {
 	const [typed, setTyped] = useState("");
 	const [loading, setLoading] = useState(true);
 
-	const ids = wordIds
-		? wordIds
-				.split(",")
-				.map(Number)
-				.filter((n) => !Number.isNaN(n))
-		: [];
-
+	// Parse IDs inside the effect so wordIds (stable string) is the only dep
 	useEffect(() => {
+		const ids = parseWordIds(wordIds);
 		if (!ids.length || !user?.language_speak) return;
+		setLoading(true);
 		wordsRepository
 			.getByRemoteIds(ids, user.language_learn ?? "en")
 			.then(async (fetchedWords) => {
@@ -58,13 +62,12 @@ export default function WordIntro() {
 				const loadedPairs = ordered
 					.map((word) => ({
 						word,
-						translation: translations.find((t) => t.word === word.remoteId),
+						translation: translations.find((tr) => tr.word === word.remoteId),
 					}))
 					.filter((p): p is WordPair => p.translation !== undefined);
 				setPairs(loadedPairs);
 			})
 			.finally(() => setLoading(false));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [wordIds, user?.language_speak, user?.language_learn]);
 
 	const handleNext = useCallback(async () => {
@@ -92,9 +95,10 @@ export default function WordIntro() {
 			.filter((r) => r.training === "intro")
 			.map((r) => r.wordId);
 
-		setChunkWordIds(allIntroducedIds.length > 0 ? allIntroducedIds : ids);
+		const fallbackIds = parseWordIds(wordIds);
+		setChunkWordIds(allIntroducedIds.length > 0 ? allIntroducedIds : fallbackIds);
 		router.replace("/authorized/learning/mix-training");
-	}, [pairs, currentIndex, user, ids, setChunkWordIds]);
+	}, [pairs, currentIndex, user, wordIds, setChunkWordIds]);
 
 	if (loading) {
 		return (
@@ -135,12 +139,7 @@ export default function WordIntro() {
 
 						<View style={styles.divider} />
 
-						<WText
-							mode="primary"
-							size="xl"
-							wrap
-							style={styles.translation}
-						>
+						<WText mode="primary" size="xl" wrap style={styles.translation}>
 							{pair.translation.translation}
 						</WText>
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",

--- a/context/ExerciseContext.tsx
+++ b/context/ExerciseContext.tsx
@@ -129,6 +129,7 @@ export const ExerciseProvider = ({ children }: ExerciseProviderProps) => {
 		setCurrentPairs,
 		setCurrentRandomWords,
 		setCurrentRandomTranslations,
+		chunkWordIds,
 	} = useExcerciseStore();
 
 	const addCompleteListener = useCallback((listener: () => void) => {
@@ -195,6 +196,11 @@ export const ExerciseProvider = ({ children }: ExerciseProviderProps) => {
 					}))
 					.filter((p): p is SessionPair => p.translation !== undefined);
 
+				const pairsToUse =
+					chunkWordIds != null && chunkWordIds.length > 0
+						? allPairs.filter((p) => chunkWordIds.includes(p.word.remoteId))
+						: allPairs;
+
 				if (user?.userId) {
 					const progressRecords =
 						trainingId != null
@@ -204,13 +210,15 @@ export const ExerciseProvider = ({ children }: ExerciseProviderProps) => {
 						progressRecords.map((r) => [r.wordId, r]),
 					);
 					const succeededWordIds = new Set(
-						progressRecords.map((r) => r.wordId),
+						progressRecords
+							.filter((r) => r.score > 0 && r.training !== "intro")
+							.map((r) => r.wordId),
 					);
 
 					const failed: SessionPair[] = [];
 					const succeeded: SessionPair[] = [];
 
-					for (const pair of allPairs) {
+					for (const pair of pairsToUse) {
 						if (succeededWordIds.has(pair.word.remoteId)) {
 							succeeded.push(pair);
 						} else {
@@ -233,7 +241,7 @@ export const ExerciseProvider = ({ children }: ExerciseProviderProps) => {
 				}
 
 				return {
-					failed: allPairs.sort(() => Math.random() - 0.5),
+					failed: pairsToUse.sort(() => Math.random() - 0.5),
 					succeeded: [],
 				};
 			} catch (error) {
@@ -244,7 +252,7 @@ export const ExerciseProvider = ({ children }: ExerciseProviderProps) => {
 				};
 			}
 		},
-		[currentCatalogs, currentTopics, user],
+		[currentCatalogs, currentTopics, user, chunkWordIds],
 	);
 
 	const resetSessionStats = useCallback(() => {

--- a/db/repositories/learning.repository.ts
+++ b/db/repositories/learning.repository.ts
@@ -54,11 +54,14 @@ export const learningRepository = {
 		if (result === "failure") {
 			if (existing.length > 0) {
 				await database.write(async () => {
-					await existing[0].destroyPermanently();
+					await existing[0].update((r) => {
+						r.score = 0;
+						r.lastReview = now;
+					});
 				});
-				logger.debug("learning_progress: deleted (failure)", { userId, wordId, trainingId }, "db");
+				logger.debug("learning_progress: reset to 0 (failure)", { userId, wordId, trainingId }, "db");
 			} else {
-				logger.debug("learning_progress: failure but no record to delete", { userId, wordId, trainingId }, "db");
+				logger.debug("learning_progress: failure but no record to reset", { userId, wordId, trainingId }, "db");
 			}
 			return null;
 		}
@@ -193,6 +196,50 @@ export const learningRepository = {
 			.get<LearningProgress>("learning_progress")
 			.query(Q.where("user_id", userId))
 			.observe();
+	},
+
+	async recordIntro(params: { userId: number; wordId: number; translationId?: number }): Promise<void> {
+		const { userId, wordId, translationId } = params;
+		const now = new Date().toISOString();
+
+		const existing = await database
+			.get<LearningProgress>("learning_progress")
+			.query(
+				Q.where("user_id", userId),
+				Q.where("word_id", wordId),
+				Q.where("training", "intro"),
+			)
+			.fetch();
+
+		if (existing.length > 0) return;
+
+		await database.write(async () => {
+			await database
+				.get<LearningProgress>("learning_progress")
+				.create((r) => {
+					r.userId = userId;
+					r.wordId = wordId;
+					r.score = 1;
+					r.lastReview = now;
+					r.createdAtRemote = now;
+					r.training = "intro";
+					if (translationId !== undefined) r.translation = translationId;
+				});
+		});
+		logger.debug("learning_progress: intro recorded", { userId, wordId }, "db");
+	},
+
+	async getIntroducedWordIds(userId: number, wordIds: number[]): Promise<number[]> {
+		if (wordIds.length === 0) return [];
+		const records = await database
+			.get<LearningProgress>("learning_progress")
+			.query(
+				Q.where("user_id", userId),
+				Q.where("training", "intro"),
+				Q.where("word_id", Q.oneOf(wordIds)),
+			)
+			.fetch();
+		return records.map((r) => r.wordId);
 	},
 
 	async getTopicScores(

--- a/db/repositories/words.repository.ts
+++ b/db/repositories/words.repository.ts
@@ -201,6 +201,38 @@ export const wordsRepository = {
     return new Set(words.map((word) => word.topic));
   },
 
+  async getOrderedUntrainedWords(
+    language: string,
+    count: number,
+    userId: number,
+    topics?: number[],
+    catalogs?: number[],
+  ): Promise<Word[]> {
+    const queryConditions = [Q.where("language", language)];
+    if (catalogs && catalogs.length > 0) {
+      queryConditions.push(Q.where("catalog", Q.oneOf(catalogs)));
+    }
+    if (topics && topics.length > 0) {
+      queryConditions.push(Q.where("topic", Q.oneOf(topics)));
+    }
+
+    const allWords = await database
+      .get<Word>("words")
+      .query(...queryConditions, Q.sortBy("remote_id", Q.asc))
+      .fetch();
+
+    const progressRecords = await database
+      .get<LearningProgress>("learning_progress")
+      .query(Q.where("user_id", userId))
+      .fetch();
+
+    const wordIdsWithProgress = new Set(progressRecords.map((r) => r.wordId));
+
+    return allWords
+      .filter((word) => !wordIdsWithProgress.has(word.remoteId))
+      .slice(0, count);
+  },
+
   async getByRemoteIds(remoteIds: number[], language: string): Promise<Word[]> {
     if (remoteIds.length === 0) return [];
     return database

--- a/hooks/useChunkManagement.ts
+++ b/hooks/useChunkManagement.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+import { userSettingsRepository } from "@/db/repositories/userSettings.repository";
+
+const PROPOSAL_KEY_PREFIX = "daily_word_proposal";
+export const CHUNK_SIZE = 5;
+
+function getProposalKey(topicIds: number[], catalogIds: number[]): string {
+	const ids = topicIds.length > 0 ? topicIds : catalogIds;
+	return `${PROPOSAL_KEY_PREFIX}_${[...ids].sort().join("-")}`;
+}
+
+function isToday(isoString: string): boolean {
+	return new Date(isoString).toDateString() === new Date().toDateString();
+}
+
+interface ChunkManagement {
+	shouldShowProposal: boolean;
+	loading: boolean;
+	markProposed: () => Promise<void>;
+}
+
+export function useChunkManagement(
+	userId: string | undefined,
+	topicIds: number[],
+	catalogIds: number[],
+): ChunkManagement {
+	const [lastProposedDate, setLastProposedDate] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	const key = getProposalKey(topicIds, catalogIds);
+
+	useEffect(() => {
+		if (!userId) {
+			setLoading(false);
+			return;
+		}
+		setLoading(true);
+		userSettingsRepository
+			.get(userId, key)
+			.then((value) => setLastProposedDate(value))
+			.finally(() => setLoading(false));
+	}, [userId, key]);
+
+	const shouldShowProposal =
+		!loading && (!lastProposedDate || !isToday(lastProposedDate));
+
+	const markProposed = useCallback(async () => {
+		if (!userId) return;
+		const now = new Date().toISOString();
+		setLastProposedDate(now);
+		await userSettingsRepository.set(userId, key, now);
+	}, [userId, key]);
+
+	return { shouldShowProposal, loading, markProposed };
+}

--- a/hooks/useExcerciseStore.ts
+++ b/hooks/useExcerciseStore.ts
@@ -14,6 +14,7 @@ type ExcerciseState = {
 	currentRandomTranslations: WordTranslation[];
 	_hasHydrated: boolean;
 	topicsInitialized: boolean;
+	chunkWordIds: number[] | null;
 };
 
 type ExcerciseActions = {
@@ -26,6 +27,7 @@ type ExcerciseActions = {
 	setCurrentRandomTranslations: (translations: WordTranslation[]) => void;
 	setHasHydrated: (value: boolean) => void;
 	setTopicsInitialized: (value: boolean) => void;
+	setChunkWordIds: (ids: number[] | null) => void;
 	reset: () => void;
 };
 
@@ -37,6 +39,7 @@ const initialState: ExcerciseState = {
 	currentRandomTranslations: [],
 	_hasHydrated: false,
 	topicsInitialized: false,
+	chunkWordIds: null,
 };
 
 export const useExcerciseStore = create<ExcerciseState & ExcerciseActions>()(
@@ -70,6 +73,10 @@ export const useExcerciseStore = create<ExcerciseState & ExcerciseActions>()(
 		setTopicsInitialized: (value: boolean) =>
 			set((state) => {
 				state.topicsInitialized = value;
+			}),
+		setChunkWordIds: (ids) =>
+			set((state) => {
+				state.chunkWordIds = ids;
 			}),
 		reset: () =>
 			set((state) => {

--- a/locales/de.json
+++ b/locales/de.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "Dieses Thema ist abgeschlossen",
 	"topic_mastered_description": "Du kannst hier bleiben oder mit {{topic}} weitermachen.",
 	"topic_mastered_stay": "Bei diesem Thema bleiben",
-	"topic_mastered_next": "Nächstes Thema"
+	"topic_mastered_next": "Nächstes Thema",
+	"daily_proposal_title": "Today I suggest learning {{count}} new words",
+	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
+	"daily_proposal_learn": "Learn new words",
+	"daily_proposal_train_chunk": "Train introduced words",
+	"daily_proposal_train_all": "Train all words in topic",
+	"word_intro_next": "Next word",
+	"word_intro_done": "Start training",
+	"word_intro_type_hint": "Try typing the word to memorize it"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -124,12 +124,12 @@
 	"topic_mastered_description": "Du kannst hier bleiben oder mit {{topic}} weitermachen.",
 	"topic_mastered_stay": "Bei diesem Thema bleiben",
 	"topic_mastered_next": "Nächstes Thema",
-	"daily_proposal_title": "Today I suggest learning {{count}} new words",
-	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
-	"daily_proposal_learn": "Learn new words",
-	"daily_proposal_train_chunk": "Train introduced words",
-	"daily_proposal_train_all": "Train all words in topic",
-	"word_intro_next": "Next word",
-	"word_intro_done": "Start training",
-	"word_intro_type_hint": "Try typing the word to memorize it"
+	"daily_proposal_title": "Heute schlage ich vor, {{count}} neue Wörter zu lernen",
+	"daily_proposal_description": "Lerne zunächst die Wörter kennen, dann übe mit Aufgaben.",
+	"daily_proposal_learn": "Neue Wörter lernen",
+	"daily_proposal_train_chunk": "Gelernte Wörter üben",
+	"daily_proposal_train_all": "Alle Wörter des Themas üben",
+	"word_intro_next": "Nächstes Wort",
+	"word_intro_done": "Training starten",
+	"word_intro_type_hint": "Versuche, das Wort einzutippen, um es zu merken"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "Αυτή η θεματική ολοκληρώθηκε",
 	"topic_mastered_description": "Μπορείτε να μείνετε εδώ ή να προχωρήσετε στην επόμενη θεματική: {{topic}}.",
 	"topic_mastered_stay": "Μείνετε σε αυτή τη θεματική",
-	"topic_mastered_next": "Επόμενη θεματική"
+	"topic_mastered_next": "Επόμενη θεματική",
+	"daily_proposal_title": "Today I suggest learning {{count}} new words",
+	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
+	"daily_proposal_learn": "Learn new words",
+	"daily_proposal_train_chunk": "Train introduced words",
+	"daily_proposal_train_all": "Train all words in topic",
+	"word_intro_next": "Next word",
+	"word_intro_done": "Start training",
+	"word_intro_type_hint": "Try typing the word to memorize it"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -124,12 +124,12 @@
 	"topic_mastered_description": "Μπορείτε να μείνετε εδώ ή να προχωρήσετε στην επόμενη θεματική: {{topic}}.",
 	"topic_mastered_stay": "Μείνετε σε αυτή τη θεματική",
 	"topic_mastered_next": "Επόμενη θεματική",
-	"daily_proposal_title": "Today I suggest learning {{count}} new words",
-	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
-	"daily_proposal_learn": "Learn new words",
-	"daily_proposal_train_chunk": "Train introduced words",
-	"daily_proposal_train_all": "Train all words in topic",
-	"word_intro_next": "Next word",
-	"word_intro_done": "Start training",
-	"word_intro_type_hint": "Try typing the word to memorize it"
+	"daily_proposal_title": "Σήμερα προτείνω να μάθεις {{count}} νέες λέξεις",
+	"daily_proposal_description": "Ξεκίνα με εξοικείωση στις λέξεις, έπειτα εξάσκησε με ασκήσεις.",
+	"daily_proposal_learn": "Μάθε νέες λέξεις",
+	"daily_proposal_train_chunk": "Εξάσκηση στις εισαγμένες λέξεις",
+	"daily_proposal_train_all": "Εξάσκηση σε όλες τις λέξεις του θέματος",
+	"word_intro_next": "Επόμενη λέξη",
+	"word_intro_done": "Έναρξη εκπαίδευσης",
+	"word_intro_type_hint": "Δοκίμασε να πληκτρολογήσεις τη λέξη για να την αποστηθίσεις"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "This topic is completed",
 	"topic_mastered_description": "You can keep practicing here or move on to {{topic}}.",
 	"topic_mastered_stay": "Stay on this topic",
-	"topic_mastered_next": "Next topic"
+	"topic_mastered_next": "Next topic",
+	"daily_proposal_title": "Today I suggest learning {{count}} new words",
+	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
+	"daily_proposal_learn": "Learn new words",
+	"daily_proposal_train_chunk": "Train introduced words",
+	"daily_proposal_train_all": "Train all words in topic",
+	"word_intro_next": "Next word",
+	"word_intro_done": "Start training",
+	"word_intro_type_hint": "Try typing the word to memorize it"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -124,12 +124,12 @@
 	"topic_mastered_description": "Puedes seguir aquí o pasar al siguiente tema: {{topic}}.",
 	"topic_mastered_stay": "Quedarme en este tema",
 	"topic_mastered_next": "Siguiente tema",
-	"daily_proposal_title": "Today I suggest learning {{count}} new words",
-	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
-	"daily_proposal_learn": "Learn new words",
-	"daily_proposal_train_chunk": "Train introduced words",
-	"daily_proposal_train_all": "Train all words in topic",
-	"word_intro_next": "Next word",
-	"word_intro_done": "Start training",
-	"word_intro_type_hint": "Try typing the word to memorize it"
+	"daily_proposal_title": "Hoy te sugiero aprender {{count}} palabras nuevas",
+	"daily_proposal_description": "Empieza familiarizándote con las palabras y luego practica con ejercicios.",
+	"daily_proposal_learn": "Aprender palabras nuevas",
+	"daily_proposal_train_chunk": "Entrenar palabras introducidas",
+	"daily_proposal_train_all": "Entrenar todas las palabras del tema",
+	"word_intro_next": "Siguiente palabra",
+	"word_intro_done": "Empezar entrenamiento",
+	"word_intro_type_hint": "Intenta escribir la palabra para memorizarla"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "Este tema ya está completado",
 	"topic_mastered_description": "Puedes seguir aquí o pasar al siguiente tema: {{topic}}.",
 	"topic_mastered_stay": "Quedarme en este tema",
-	"topic_mastered_next": "Siguiente tema"
+	"topic_mastered_next": "Siguiente tema",
+	"daily_proposal_title": "Today I suggest learning {{count}} new words",
+	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
+	"daily_proposal_learn": "Learn new words",
+	"daily_proposal_train_chunk": "Train introduced words",
+	"daily_proposal_train_all": "Train all words in topic",
+	"word_intro_next": "Next word",
+	"word_intro_done": "Start training",
+	"word_intro_type_hint": "Try typing the word to memorize it"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -124,12 +124,12 @@
 	"topic_mastered_description": "Vous pouvez rester ici ou passer au thème suivant : {{topic}}.",
 	"topic_mastered_stay": "Rester sur ce thème",
 	"topic_mastered_next": "Thème suivant",
-	"daily_proposal_title": "Today I suggest learning {{count}} new words",
-	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
-	"daily_proposal_learn": "Learn new words",
-	"daily_proposal_train_chunk": "Train introduced words",
-	"daily_proposal_train_all": "Train all words in topic",
-	"word_intro_next": "Next word",
-	"word_intro_done": "Start training",
-	"word_intro_type_hint": "Try typing the word to memorize it"
+	"daily_proposal_title": "Aujourd'hui je te propose d'apprendre {{count}} nouveaux mots",
+	"daily_proposal_description": "Commence par te familiariser avec les mots, puis entraîne-toi avec des exercices.",
+	"daily_proposal_learn": "Apprendre de nouveaux mots",
+	"daily_proposal_train_chunk": "Entraîner les mots introduits",
+	"daily_proposal_train_all": "Entraîner tous les mots du thème",
+	"word_intro_next": "Mot suivant",
+	"word_intro_done": "Commencer l'entraînement",
+	"word_intro_type_hint": "Essaie de taper le mot pour le mémoriser"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "Ce thème est terminé",
 	"topic_mastered_description": "Vous pouvez rester ici ou passer au thème suivant : {{topic}}.",
 	"topic_mastered_stay": "Rester sur ce thème",
-	"topic_mastered_next": "Thème suivant"
+	"topic_mastered_next": "Thème suivant",
+	"daily_proposal_title": "Today I suggest learning {{count}} new words",
+	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
+	"daily_proposal_learn": "Learn new words",
+	"daily_proposal_train_chunk": "Train introduced words",
+	"daily_proposal_train_all": "Train all words in topic",
+	"word_intro_next": "Next word",
+	"word_intro_done": "Start training",
+	"word_intro_type_hint": "Try typing the word to memorize it"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "Questo argomento è completato",
 	"topic_mastered_description": "Puoi restare qui oppure passare al prossimo argomento: {{topic}}.",
 	"topic_mastered_stay": "Resta su questo argomento",
-	"topic_mastered_next": "Argomento successivo"
+	"topic_mastered_next": "Argomento successivo",
+	"daily_proposal_title": "Today I suggest learning {{count}} new words",
+	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
+	"daily_proposal_learn": "Learn new words",
+	"daily_proposal_train_chunk": "Train introduced words",
+	"daily_proposal_train_all": "Train all words in topic",
+	"word_intro_next": "Next word",
+	"word_intro_done": "Start training",
+	"word_intro_type_hint": "Try typing the word to memorize it"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -124,12 +124,12 @@
 	"topic_mastered_description": "Puoi restare qui oppure passare al prossimo argomento: {{topic}}.",
 	"topic_mastered_stay": "Resta su questo argomento",
 	"topic_mastered_next": "Argomento successivo",
-	"daily_proposal_title": "Today I suggest learning {{count}} new words",
-	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
-	"daily_proposal_learn": "Learn new words",
-	"daily_proposal_train_chunk": "Train introduced words",
-	"daily_proposal_train_all": "Train all words in topic",
-	"word_intro_next": "Next word",
-	"word_intro_done": "Start training",
-	"word_intro_type_hint": "Try typing the word to memorize it"
+	"daily_proposal_title": "Oggi ti propongo di imparare {{count}} parole nuove",
+	"daily_proposal_description": "Inizia familiarizzando con le parole, poi esercitati con gli esercizi.",
+	"daily_proposal_learn": "Imparare parole nuove",
+	"daily_proposal_train_chunk": "Allenare le parole introdotte",
+	"daily_proposal_train_all": "Allenare tutte le parole del tema",
+	"word_intro_next": "Parola successiva",
+	"word_intro_done": "Inizia allenamento",
+	"word_intro_type_hint": "Prova a digitare la parola per memorizzarla"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "Dit onderwerp is voltooid",
 	"topic_mastered_description": "Je kunt hier blijven of doorgaan naar {{topic}}.",
 	"topic_mastered_stay": "Blijf bij dit onderwerp",
-	"topic_mastered_next": "Volgend onderwerp"
+	"topic_mastered_next": "Volgend onderwerp",
+	"daily_proposal_title": "Today I suggest learning {{count}} new words",
+	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
+	"daily_proposal_learn": "Learn new words",
+	"daily_proposal_train_chunk": "Train introduced words",
+	"daily_proposal_train_all": "Train all words in topic",
+	"word_intro_next": "Next word",
+	"word_intro_done": "Start training",
+	"word_intro_type_hint": "Try typing the word to memorize it"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -124,12 +124,12 @@
 	"topic_mastered_description": "Je kunt hier blijven of doorgaan naar {{topic}}.",
 	"topic_mastered_stay": "Blijf bij dit onderwerp",
 	"topic_mastered_next": "Volgend onderwerp",
-	"daily_proposal_title": "Today I suggest learning {{count}} new words",
-	"daily_proposal_description": "Start by getting familiar with the words, then practice with exercises.",
-	"daily_proposal_learn": "Learn new words",
-	"daily_proposal_train_chunk": "Train introduced words",
-	"daily_proposal_train_all": "Train all words in topic",
-	"word_intro_next": "Next word",
-	"word_intro_done": "Start training",
-	"word_intro_type_hint": "Try typing the word to memorize it"
+	"daily_proposal_title": "Vandaag stel ik voor om {{count}} nieuwe woorden te leren",
+	"daily_proposal_description": "Begin met het verkennen van de woorden, oefen daarna met oefeningen.",
+	"daily_proposal_learn": "Nieuwe woorden leren",
+	"daily_proposal_train_chunk": "Geïntroduceerde woorden oefenen",
+	"daily_proposal_train_all": "Alle woorden van het onderwerp oefenen",
+	"word_intro_next": "Volgend woord",
+	"word_intro_done": "Training starten",
+	"word_intro_type_hint": "Probeer het woord te typen om het te onthouden"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -123,5 +123,13 @@
 	"topic_mastered_title": "Тема полностью пройдена",
 	"topic_mastered_description": "Можно остаться на этой теме или перейти к следующей: {{topic}}.",
 	"topic_mastered_stay": "Остаться на теме",
-	"topic_mastered_next": "Следующая тема"
+	"topic_mastered_next": "Следующая тема",
+	"daily_proposal_title": "Сегодня предлагаю изучить {{count}} новых слов",
+	"daily_proposal_description": "Сначала познакомьтесь со словами, затем закрепите упражнениями.",
+	"daily_proposal_learn": "Изучить новые слова",
+	"daily_proposal_train_chunk": "Тренировать изученные слова",
+	"daily_proposal_train_all": "Тренировать все слова темы",
+	"word_intro_next": "Следующее слово",
+	"word_intro_done": "Начать тренировку",
+	"word_intro_type_hint": "Попробуйте напечатать слово для запоминания"
 }


### PR DESCRIPTION
- Fix: failed exercises no longer reset progress to zero; instead, score
  is kept at 0 so failed words remain in the training queue without
  triggering the intro-card flow again
- ExerciseContext: success queue now requires score > 0 (excluding intro
  records) so failed/intro-only words stay in the primary training queue
- New daily proposal screen: once per day (if untrained words exist) the
  Learning tab shows "Learn N new words" with three choices:
    1. Learn – runs intro card flow for the next CHUNK_SIZE untrained words
    2. Train introduced words – mix-training restricted to introduced chunk
    3. Train all words – normal full-topic mix-training
- New word-intro screen: shows each word with translation, audio and an
  optional typing field before exercises; records training="intro" on
  completion and navigates to chunk-filtered mix-training
- words.repository: getOrderedUntrainedWords fetches untrained words in
  stable order (by remote_id) for consistent chunk assignment
- learning.repository: recordIntro / getIntroducedWordIds for intro tracking
- useExcerciseStore: chunkWordIds field to filter exercises to a word subset
- useChunkManagement hook: persists last-proposal date via userSettings DB

https://claude.ai/code/session_019vMmWJQJ12ofHt9fGnhAaw